### PR TITLE
Corrected capitalization of author's name

### DIFF
--- a/_posts/2020-11-21-debenedetto20a.md
+++ b/_posts/2020-11-21-debenedetto20a.md
@@ -25,10 +25,10 @@ lastpage: 2420
 page: 2412-2420
 order: 2412
 cycles: false
-bibtex_author: Debenedetto, Justin and Chiang, David
+bibtex_author: DeBenedetto, Justin and Chiang, David
 author:
 - given: Justin
-  family: Debenedetto
+  family: DeBenedetto
 - given: David
   family: Chiang
 date: 2020-11-21

--- a/_posts/2020-11-21-debenedetto20a.md
+++ b/_posts/2020-11-21-debenedetto20a.md
@@ -25,7 +25,7 @@ lastpage: 2420
 page: 2412-2420
 order: 2412
 cycles: false
-bibtex_author: DeBenedetto, Justin and Chiang, David
+bibtex_author: De{B}enedetto, Justin and Chiang, David
 author:
 - given: Justin
   family: DeBenedetto


### PR DESCRIPTION
My name was not capitalized correctly on the page or in the citation the page generated.